### PR TITLE
Allow ChangeSID to be set

### DIFF
--- a/vapp.go
+++ b/vapp.go
@@ -396,7 +396,10 @@ func (v *VApp) Delete() (Task, error) {
 }
 
 func (v *VApp) RunCustomizationScript(computername, script string) (Task, error) {
+	return v.Customize(computername, script, false)
+}
 
+func (v *VApp) Customize(computername, script string, changeSid bool) (Task, error) {
 	err := v.Refresh()
 	if err != nil {
 		return Task{}, fmt.Errorf("error refreshing vapp before running customization: %v", err)
@@ -418,6 +421,7 @@ func (v *VApp) RunCustomizationScript(computername, script string) (Task, error)
 		Enabled:             true,
 		ComputerName:        computername,
 		CustomizationScript: script,
+		ChangeSid:           false,
 	}
 
 	output, err := xml.MarshalIndent(vu, "  ", "    ")


### PR DESCRIPTION
We have a requirement to be able to set this flag when creating new vapps in VCloud Director via Terraform, so surfacing that flag via this library is a pre-requisite. Is this a change you'd be interested in? We're working on a separate PR on the main terraform project to surface a `change_sid` property on the VApp resource.