### PR TITLE
Add Nat Port Mapping support

### DIFF
--- a/edgegateway.go
+++ b/edgegateway.go
@@ -115,6 +115,10 @@ func (e *EdgeGateway) AddDhcpPool(network *types.OrgVDCNetwork, dhcppool []inter
 }
 
 func (e *EdgeGateway) RemoveNATMapping(nattype, externalIP, internalIP, port string) (Task, error) {
+	return e.RemoveNATPortMapping(nattype, externalIP, port, internalIP, port)
+}
+
+func (e *EdgeGateway) RemoveNATPortMapping(nattype, externalIP, externalPort string, internalIP, internalPort string) (Task, error) {
 	// Find uplink interface
 	var uplink types.Reference
 	for _, gi := range e.EdgeGateway.Configuration.GatewayInterfaces.GatewayInterface {
@@ -140,7 +144,7 @@ func (e *EdgeGateway) RemoveNATMapping(nattype, externalIP, internalIP, port str
 		// If matches, let's skip it and continue the loop
 		if v.RuleType == nattype &&
 			v.GatewayNatRule.OriginalIP == externalIP &&
-			v.GatewayNatRule.OriginalPort == port &&
+			v.GatewayNatRule.OriginalPort == externalPort &&
 			v.GatewayNatRule.Interface.HREF == uplink.HREF {
 			log.Printf("[DEBUG] REMOVING %s Rule: %#v", v.RuleType, v.GatewayNatRule)
 			continue
@@ -190,6 +194,10 @@ func (e *EdgeGateway) RemoveNATMapping(nattype, externalIP, internalIP, port str
 }
 
 func (e *EdgeGateway) AddNATMapping(nattype, externalIP, internalIP, port string) (Task, error) {
+	return e.AddNATPortMapping(nattype, externalIP, port, internalIP, port)
+}
+
+func (e *EdgeGateway) AddNATPortMapping(nattype, externalIP, externalPort string, internalIP, internalPort string) (Task, error) {
 	// Find uplink interface
 	var uplink types.Reference
 	for _, gi := range e.EdgeGateway.Configuration.GatewayInterfaces.GatewayInterface {
@@ -218,8 +226,9 @@ func (e *EdgeGateway) AddNATMapping(nattype, externalIP, internalIP, port string
 			// If matches, let's skip it and continue the loop
 			if v.RuleType == nattype &&
 				v.GatewayNatRule.OriginalIP == externalIP &&
-				v.GatewayNatRule.OriginalPort == port &&
+				v.GatewayNatRule.OriginalPort == externalPort &&
 				v.GatewayNatRule.TranslatedIP == internalIP &&
+				v.GatewayNatRule.TranslatedPort == internalPort &&
 				v.GatewayNatRule.Interface.HREF == uplink.HREF {
 				continue
 			}
@@ -237,9 +246,9 @@ func (e *EdgeGateway) AddNATMapping(nattype, externalIP, internalIP, port string
 				HREF: uplink.HREF,
 			},
 			OriginalIP:     externalIP,
-			OriginalPort:   port,
+			OriginalPort:   externalPort,
 			TranslatedIP:   internalIP,
-			TranslatedPort: port,
+			TranslatedPort: internalPort,
 			Protocol:       "tcp",
 		},
 	}

--- a/edgegateway_test.go
+++ b/edgegateway_test.go
@@ -70,6 +70,41 @@ func (s *S) Test_NATMapping(c *C) {
 
 }
 
+func (s *S) Test_NATPortMapping(c *C) {
+	testServer.ResponseMap(2, testutil.ResponseMap{
+		"/api/vdc/00000000-0000-0000-0000-000000000000/edgeGateways":  testutil.Response{200, nil, edgegatewayqueryresultsExample},
+		"/api/admin/edgeGateway/00000000-0000-0000-0000-000000000000": testutil.Response{200, nil, edgegatewayExample},
+	})
+
+	edge, err := s.vdc.FindEdgeGateway("M916272752-5793")
+	_ = testServer.WaitRequests(2)
+	testServer.Flush()
+
+	c.Assert(err, IsNil)
+	c.Assert(edge.EdgeGateway.Name, Equals, "M916272752-5793")
+
+	testServer.ResponseMap(2, testutil.ResponseMap{
+		"/api/admin/edgeGateway/00000000-0000-0000-0000-000000000000":                          testutil.Response{200, nil, edgegatewayExample},
+		"/api/admin/edgeGateway/00000000-0000-0000-0000-000000000000/action/configureServices": testutil.Response{200, nil, taskExample},
+	})
+
+	_, err = edge.AddNATPortMapping("DNAT", "10.0.0.1", "1177", "20.0.0.2", "77")
+	_ = testServer.WaitRequest()
+
+	c.Assert(err, IsNil)
+
+	testServer.ResponseMap(2, testutil.ResponseMap{
+		"/api/admin/edgeGateway/00000000-0000-0000-0000-000000000000":                          testutil.Response{200, nil, edgegatewayExample},
+		"/api/admin/edgeGateway/00000000-0000-0000-0000-000000000000/action/configureServices": testutil.Response{200, nil, taskExample},
+	})
+
+	_, err = edge.RemoveNATPortMapping("DNAT", "10.0.0.1", "1177", "20.0.0.2", "77")
+	_ = testServer.WaitRequest()
+
+	c.Assert(err, IsNil)
+
+}
+
 func (s *S) Test_1to1Mappings(c *C) {
 
 	testServer.ResponseMap(2, testutil.ResponseMap{


### PR DESCRIPTION
Allows specifying separate originalPort and translatedPort, so one can configure more flexible DNAT port mapping for the Edge Gateway.
