### PR TITLE
change header when retrieving vdc org and avoir 500 error

### DIFF
--- a/api_vcd.go
+++ b/api_vcd.go
@@ -141,7 +141,7 @@ func (c *VCDClient) vcdauthorize(user, pass, org string) error {
 func (c *VCDClient) RetrieveOrg(vcdname string) (Org, error) {
 
 	req := c.Client.NewRequest(map[string]string{}, "GET", c.OrgHREF, nil)
-	req.Header.Add("Accept", "vnd.vmware.vcloud.org+xml;version=5.5")
+	req.Header.Add("Accept", "application/*+xml;version=5.5")
 
 	// TODO: wrap into checkresp to parse error
 	resp, err := checkResp(c.Client.Http.Do(req))


### PR DESCRIPTION
Terraform use govcloudair for the VCD provider. I encountered a problem to contact our vcd api, defined in the following issue: https://github.com/hashicorp/terraform/issues/13331 

Changing the header req.Header.Add("Accept", "application/*+xml;version=5.5") works with govcloudair, and is more coherent with other headers used in the same file.