### PR TITLE
support defining the network ip allocation mode when composing a vApp

### DIFF
--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -42,6 +42,12 @@ var VDCStatuses = map[int]string{
 	3:  "UNRECOGNIZED",
 }
 
+// Defines the network and IP mode (POOL, DHCP, MANUAL) for a VM NIC adapter
+type VAppVDCNetworkAllocation struct {
+	VAppNetwork *OrgVDCNetwork
+	IPAddressAllocationMode string
+}
+
 // VCD API
 
 // DefaultStorageProfileSection is the name of the storage profile that will be specified for this virtual machine. The named storage profile must exist in the organization vDC that contains the virtual machine. If not specified, the default storage profile for the vDC is used.

--- a/vapp.go
+++ b/vapp.go
@@ -184,9 +184,9 @@ func (v *VApp) RemoveVM(vm VM) error {
 	return nil
 }
 
-func (v *VApp) ComposeVApp(orgvdcnetworks []*types.OrgVDCNetwork, vapptemplate VAppTemplate, storageprofileref types.Reference, name string, description string) (Task, error) {
+func (v *VApp) ComposeVApp(networkAllocations []types.VAppVDCNetworkAllocation, vapptemplate VAppTemplate, storageprofileref types.Reference, name string, description string) (Task, error) {
 
-	if vapptemplate.VAppTemplate.Children == nil || orgvdcnetworks == nil {
+	if vapptemplate.VAppTemplate.Children == nil || networkAllocations == nil {
 		return Task{}, fmt.Errorf("can't compose a new vApp, objects passed are not valid")
 	}
 
@@ -220,32 +220,32 @@ func (v *VApp) ComposeVApp(orgvdcnetworks []*types.OrgVDCNetwork, vapptemplate V
 		},
 	}
 
-	for index, orgvdcnetwork := range orgvdcnetworks {
+	for index, vAppVDCNetworkAllocation := range networkAllocations {
 		vcomp.InstantiationParams.NetworkConfigSection.NetworkConfig = append(vcomp.InstantiationParams.NetworkConfigSection.NetworkConfig,
 			types.VAppNetworkConfiguration{
-				NetworkName: orgvdcnetwork.Name,
+				NetworkName: vAppVDCNetworkAllocation.VAppNetwork.Name,
 				Configuration: &types.NetworkConfiguration{
 					FenceMode: "bridged",
 					ParentNetwork: &types.Reference{
-						HREF: orgvdcnetwork.HREF,
-						Name: orgvdcnetwork.Name,
-						Type: orgvdcnetwork.Type,
+						HREF: vAppVDCNetworkAllocation.VAppNetwork.HREF,
+						Name: vAppVDCNetworkAllocation.VAppNetwork.Name,
+						Type: vAppVDCNetworkAllocation.VAppNetwork.Type,
 					},
 				},
 			},
 		)
 		vcomp.SourcedItem.InstantiationParams.NetworkConnectionSection.NetworkConnection = append(vcomp.SourcedItem.InstantiationParams.NetworkConnectionSection.NetworkConnection,
 			&types.NetworkConnection{
-				Network:                 orgvdcnetwork.Name,
+				Network:                 vAppVDCNetworkAllocation.VAppNetwork.Name,
 				NetworkConnectionIndex:  index,
 				IsConnected:             true,
-				IPAddressAllocationMode: "POOL",
+				IPAddressAllocationMode: vAppVDCNetworkAllocation.IPAddressAllocationMode,
 			},
 		)
 		vcomp.SourcedItem.NetworkAssignment = append(vcomp.SourcedItem.NetworkAssignment,
 			&types.NetworkAssignment{
-				InnerNetwork:     orgvdcnetwork.Name,
-				ContainerNetwork: orgvdcnetwork.Name,
+				InnerNetwork:     vAppVDCNetworkAllocation.VAppNetwork.Name,
+				ContainerNetwork: vAppVDCNetworkAllocation.VAppNetwork.Name,
 			},
 		)
 	}

--- a/vapp_test.go
+++ b/vapp_test.go
@@ -28,9 +28,9 @@ func (s *S) Test_ComposeVApp(c *C) {
 	c.Assert(err, IsNil)
 
 	// Populate OrgVDCNetwork
-	networks := []*types.OrgVDCNetwork{}
 	net, err := s.vdc.FindVDCNetwork("networkName")
-	networks = append(networks, net.OrgVDCNetwork)
+	vAppVDCNetworkAllocationMode := types.VAppVDCNetworkAllocation{VAppNetwork: net.OrgVDCNetwork, IPAddressAllocationMode: "POOL"}
+	networkAllocations := []types.VAppVDCNetworkAllocation{vAppVDCNetworkAllocationMode}
 	c.Assert(err, IsNil)
 
 	// Populate Catalog
@@ -50,7 +50,7 @@ func (s *S) Test_ComposeVApp(c *C) {
 	c.Assert(err, IsNil)
 
 	// Compose VApp
-	task, err := s.vapp.ComposeVApp(networks, vapptemplate, storageprofileref, "name", "description")
+	task, err := s.vapp.ComposeVApp(networkAllocations, vapptemplate, storageprofileref, "name", "description")
 	c.Assert(err, IsNil)
 	c.Assert(task.Task.OperationName, Equals, "vdcInstantiateVapp")
 	c.Assert(s.vapp.VApp.HREF, Equals, "http://localhost:4444/api/vApp/vapp-00000000-0000-0000-0000-000000000000")
@@ -114,9 +114,9 @@ func (s *S) Test_SetOvf(c *C) {
 	c.Assert(err, IsNil)
 
 	// Populate OrgVDCNetwork
-	networks := []*types.OrgVDCNetwork{}
 	net, err := s.vdc.FindVDCNetwork("networkName")
-	networks = append(networks, net.OrgVDCNetwork)
+	vAppVDCNetworkAllocationMode := types.VAppVDCNetworkAllocation{VAppNetwork: net.OrgVDCNetwork, IPAddressAllocationMode: "POOL"}
+	networkAllocations := []types.VAppVDCNetworkAllocation{vAppVDCNetworkAllocationMode}
 	c.Assert(err, IsNil)
 
 	// Populate Catalog
@@ -136,7 +136,7 @@ func (s *S) Test_SetOvf(c *C) {
 	c.Assert(err, IsNil)
 
 	// Compose VApp
-	task, err := s.vapp.ComposeVApp(networks, vapptemplate, storageprofileref, "name", "description")
+	task, err := s.vapp.ComposeVApp(networkAllocations, vapptemplate, storageprofileref, "name", "description")
 	c.Assert(err, IsNil)
 	c.Assert(task.Task.OperationName, Equals, "vdcInstantiateVapp")
 	c.Assert(s.vapp.VApp.HREF, Equals, "http://localhost:4444/api/vApp/vapp-00000000-0000-0000-0000-000000000000")
@@ -170,9 +170,9 @@ func (s *S) Test_AddMetadata(c *C) {
 	c.Assert(err, IsNil)
 
 	// Populate OrgVDCNetwork
-	networks := []*types.OrgVDCNetwork{}
 	net, err := s.vdc.FindVDCNetwork("networkName")
-	networks = append(networks, net.OrgVDCNetwork)
+	vAppVDCNetworkAllocationMode := types.VAppVDCNetworkAllocation{VAppNetwork: net.OrgVDCNetwork, IPAddressAllocationMode: "POOL"}
+	networkAllocations := []types.VAppVDCNetworkAllocation{vAppVDCNetworkAllocationMode}
 	c.Assert(err, IsNil)
 
 	// Populate Catalog
@@ -192,7 +192,7 @@ func (s *S) Test_AddMetadata(c *C) {
 	c.Assert(err, IsNil)
 
 	// Compose VApp
-	task, err := s.vapp.ComposeVApp(networks, vapptemplate, storageprofileref, "name", "description")
+	task, err := s.vapp.ComposeVApp(networkAllocations, vapptemplate, storageprofileref, "name", "description")
 	c.Assert(err, IsNil)
 	c.Assert(task.Task.OperationName, Equals, "vdcInstantiateVapp")
 	c.Assert(s.vapp.VApp.HREF, Equals, "http://localhost:4444/api/vApp/vapp-00000000-0000-0000-0000-000000000000")
@@ -225,9 +225,9 @@ func (s *S) Test_ChangeStorageProfile(c *C) {
 	c.Assert(err, IsNil)
 
 	// Populate OrgVDCNetwork
-	networks := []*types.OrgVDCNetwork{}
 	net, err := s.vdc.FindVDCNetwork("networkName")
-	networks = append(networks, net.OrgVDCNetwork)
+	vAppVDCNetworkAllocationMode := types.VAppVDCNetworkAllocation{VAppNetwork: net.OrgVDCNetwork, IPAddressAllocationMode: "POOL"}
+	networkAllocations := []types.VAppVDCNetworkAllocation{vAppVDCNetworkAllocationMode}
 	c.Assert(err, IsNil)
 
 	// Populate Catalog
@@ -247,7 +247,7 @@ func (s *S) Test_ChangeStorageProfile(c *C) {
 	c.Assert(err, IsNil)
 
 	// Compose VApp
-	task, err := s.vapp.ComposeVApp(networks, vapptemplate, storageprofileref, "name", "description")
+	task, err := s.vapp.ComposeVApp(networkAllocations, vapptemplate, storageprofileref, "name", "description")
 	c.Assert(err, IsNil)
 	c.Assert(task.Task.OperationName, Equals, "vdcInstantiateVapp")
 	c.Assert(s.vapp.VApp.HREF, Equals, "http://localhost:4444/api/vApp/vapp-00000000-0000-0000-0000-000000000000")
@@ -279,9 +279,9 @@ func (s *S) Test_ChangeVMName(c *C) {
 	c.Assert(err, IsNil)
 
 	// Populate OrgVDCNetwork
-	networks := []*types.OrgVDCNetwork{}
 	net, err := s.vdc.FindVDCNetwork("networkName")
-	networks = append(networks, net.OrgVDCNetwork)
+	vAppVDCNetworkAllocationMode := types.VAppVDCNetworkAllocation{VAppNetwork: net.OrgVDCNetwork, IPAddressAllocationMode: "POOL"}
+	networkAllocations := []types.VAppVDCNetworkAllocation{vAppVDCNetworkAllocationMode}
 	c.Assert(err, IsNil)
 
 	// Populate Catalog
@@ -301,7 +301,7 @@ func (s *S) Test_ChangeVMName(c *C) {
 	c.Assert(err, IsNil)
 
 	// Compose VApp
-	task, err := s.vapp.ComposeVApp(networks, vapptemplate, storageprofileref, "name", "description")
+	task, err := s.vapp.ComposeVApp(networkAllocations, vapptemplate, storageprofileref, "name", "description")
 	c.Assert(err, IsNil)
 	c.Assert(task.Task.OperationName, Equals, "vdcInstantiateVapp")
 	c.Assert(s.vapp.VApp.HREF, Equals, "http://localhost:4444/api/vApp/vapp-00000000-0000-0000-0000-000000000000")
@@ -399,9 +399,9 @@ func (s *S) Test_RunCustomizationScript(c *C) {
 	c.Assert(err, IsNil)
 
 	// Populate OrgVDCNetwork
-	networks := []*types.OrgVDCNetwork{}
 	net, err := s.vdc.FindVDCNetwork("networkName")
-	networks = append(networks, net.OrgVDCNetwork)
+	vAppVDCNetworkAllocationMode := types.VAppVDCNetworkAllocation{VAppNetwork: net.OrgVDCNetwork, IPAddressAllocationMode: "POOL"}
+	networkAllocations := []types.VAppVDCNetworkAllocation{vAppVDCNetworkAllocationMode}
 	c.Assert(err, IsNil)
 
 	// Populate Catalog
@@ -421,7 +421,7 @@ func (s *S) Test_RunCustomizationScript(c *C) {
 	c.Assert(err, IsNil)
 
 	// Compose VApp
-	task, err := s.vapp.ComposeVApp(networks, vapptemplate, storageprofileref, "name", "description")
+	task, err := s.vapp.ComposeVApp(networkAllocations, vapptemplate, storageprofileref, "name", "description")
 	c.Assert(err, IsNil)
 	c.Assert(task.Task.OperationName, Equals, "vdcInstantiateVapp")
 	c.Assert(s.vapp.VApp.HREF, Equals, "http://localhost:4444/api/vApp/vapp-00000000-0000-0000-0000-000000000000")
@@ -453,9 +453,9 @@ func (s *S) Test_ChangeCPUcount(c *C) {
 	c.Assert(err, IsNil)
 
 	// Populate OrgVDCNetwork
-	networks := []*types.OrgVDCNetwork{}
 	net, err := s.vdc.FindVDCNetwork("networkName")
-	networks = append(networks, net.OrgVDCNetwork)
+	vAppVDCNetworkAllocationMode := types.VAppVDCNetworkAllocation{VAppNetwork: net.OrgVDCNetwork, IPAddressAllocationMode: "POOL"}
+	networkAllocations := []types.VAppVDCNetworkAllocation{vAppVDCNetworkAllocationMode}
 	c.Assert(err, IsNil)
 
 	// Populate Catalog
@@ -475,7 +475,7 @@ func (s *S) Test_ChangeCPUcount(c *C) {
 	c.Assert(err, IsNil)
 
 	// Compose VApp
-	task, err := s.vapp.ComposeVApp(networks, vapptemplate, storageprofileref, "name", "description")
+	task, err := s.vapp.ComposeVApp(networkAllocations, vapptemplate, storageprofileref, "name", "description")
 	c.Assert(err, IsNil)
 	c.Assert(task.Task.OperationName, Equals, "vdcInstantiateVapp")
 	c.Assert(s.vapp.VApp.HREF, Equals, "http://localhost:4444/api/vApp/vapp-00000000-0000-0000-0000-000000000000")
@@ -507,9 +507,9 @@ func (s *S) Test_ChangeMemorySize(c *C) {
 	c.Assert(err, IsNil)
 
 	// Populate OrgVDCNetwork
-	networks := []*types.OrgVDCNetwork{}
 	net, err := s.vdc.FindVDCNetwork("networkName")
-	networks = append(networks, net.OrgVDCNetwork)
+	vAppVDCNetworkAllocationMode := types.VAppVDCNetworkAllocation{VAppNetwork: net.OrgVDCNetwork, IPAddressAllocationMode: "POOL"}
+	networkAllocations := []types.VAppVDCNetworkAllocation{vAppVDCNetworkAllocationMode}
 	c.Assert(err, IsNil)
 
 	// Populate Catalog
@@ -529,7 +529,7 @@ func (s *S) Test_ChangeMemorySize(c *C) {
 	c.Assert(err, IsNil)
 
 	// Compose VApp
-	task, err := s.vapp.ComposeVApp(networks, vapptemplate, storageprofileref, "name", "description")
+	task, err := s.vapp.ComposeVApp(networkAllocations, vapptemplate, storageprofileref, "name", "description")
 	c.Assert(err, IsNil)
 	c.Assert(task.Task.OperationName, Equals, "vdcInstantiateVapp")
 	c.Assert(s.vapp.VApp.HREF, Equals, "http://localhost:4444/api/vApp/vapp-00000000-0000-0000-0000-000000000000")


### PR DESCRIPTION
Adds support to configure the VM's NIC adapter IP-Mode (e.g POOL, DHCP, MANUAL, NONE) during vApp composing.